### PR TITLE
[FE] マイナススコアがうまく処理できていないバグの修正

### DIFF
--- a/frontend/api/postRecord.ts
+++ b/frontend/api/postRecord.ts
@@ -1,25 +1,19 @@
 import axios from "axios";
-import { Dispatch, SetStateAction } from "react";
 
 import { baseURL } from "@/stores/Data";
 import { PostRecord } from "@/types/PostRecord";
 
-export const postRecord = (
-  data: PostRecord,
-  setState: Dispatch<SetStateAction<number>>
-) => {
-  axios
-    .post(baseURL + "/api/v1/add-record", data, {
+export const postRecord = async (data: PostRecord) => {
+  try {
+    const res = await axios.post(baseURL + "/api/v1/add-record", data, {
       headers: {
         "Content-Type": "application/json",
       },
-    })
-    .then((res) => {
-      setState(res.status);
-    })
-    .catch((error) => {
-      // eslint-disable-next-line no-console
-      console.error(error);
-      setState(-1); // セットする値は 200 以外であれば何でも良い
     });
+    return res;
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(error);
+    return null;
+  }
 };

--- a/frontend/components/molecules/ScoreInput/index.stories.tsx
+++ b/frontend/components/molecules/ScoreInput/index.stories.tsx
@@ -15,9 +15,16 @@ export default storybookObj;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const Default: StoryObj = (args: any) => {
   const [text, setText] = useState(undefined);
+  const [flag, setFlag] = useState(false);
   return (
     <>
-      <ScoreInput {...args} value={text} setState={setText} />
+      <ScoreInput
+        {...args}
+        isScoreMinus={flag}
+        setIsScoreMinus={setFlag}
+        value={text}
+        setState={setText}
+      />
 
       <p>--------------------</p>
       <p>入力された数字: {text}</p>

--- a/frontend/components/molecules/ScoreInput/index.tsx
+++ b/frontend/components/molecules/ScoreInput/index.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction, useState } from "react";
+import React, { Dispatch, SetStateAction } from "react";
 import { AiOutlineMinusSquare, AiOutlinePlusSquare } from "react-icons/ai";
 
 import { HStack, Icon } from "@chakra-ui/react";
@@ -6,20 +6,19 @@ import { HStack, Icon } from "@chakra-ui/react";
 import { RightAddonInput } from "@/components/atoms/RightAddonInput";
 
 type Props = {
+  isScoreMinus: boolean;
+  setIsScoreMinus: Dispatch<SetStateAction<boolean>>;
   value: string | undefined;
   setState: Dispatch<SetStateAction<string | undefined>>;
 };
-export const ScoreInput = ({ value, setState }: Props) => {
-  const [isMinus, setIsMinus] = useState(false);
-
+export const ScoreInput = ({
+  isScoreMinus,
+  setIsScoreMinus,
+  value,
+  setState,
+}: Props) => {
   const handleClick = () => {
-    setIsMinus(!isMinus);
-    setState((prev) => {
-      if (!prev) return prev;
-
-      const parsed = parseInt(prev, 10);
-      return isNaN(parsed) ? prev : String(parsed * -1);
-    });
+    setIsScoreMinus(!isScoreMinus);
   };
 
   return (
@@ -27,12 +26,16 @@ export const ScoreInput = ({ value, setState }: Props) => {
       <HStack>
         <Icon
           boxSize={12}
-          as={isMinus ? AiOutlineMinusSquare : AiOutlinePlusSquare}
-          color={isMinus ? "red" : "black"}
+          as={isScoreMinus ? AiOutlineMinusSquare : AiOutlinePlusSquare}
+          color={isScoreMinus ? "red" : "black"}
           _hover={{ cursor: "pointer" }}
           onClick={handleClick}
         />
-        <RightAddonInput isMinus={isMinus} value={value} setState={setState} />
+        <RightAddonInput
+          isMinus={isScoreMinus}
+          value={value}
+          setState={setState}
+        />
       </HStack>
     </>
   );

--- a/frontend/components/organisms/ScoreInputField/index.tsx
+++ b/frontend/components/organisms/ScoreInputField/index.tsx
@@ -45,7 +45,6 @@ export const ScoreInputField = ({
   const [isScoreMinus, setIsScoreMinus] = useState<boolean>(false); // スコアがマイナスかどうかの状態
   const [isValidate, setIsValidate] = useState<boolean>(false); // データを送信可能かどうかの状態
   const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [resStatus, setResStatus] = useState<number>(0);
   const toast = useToast();
 
   useEffect(() => {
@@ -63,42 +62,6 @@ export const ScoreInputField = ({
       return input.rule && input.rank && input.score ? true : false;
     });
   }, [input]);
-
-  useEffect(() => {
-    // 初期値
-    if (resStatus === 0) {
-      return;
-    }
-
-    if (resStatus !== 200) {
-      toast({
-        title: "データの送信に失敗しました",
-        status: "error",
-        position: "top",
-        duration: 3000,
-        isClosable: false,
-      });
-
-      setIsLoading(false);
-      return;
-    }
-
-    toast({
-      title: "データの送信に成功しました！",
-      status: "success",
-      position: "top",
-      duration: 3000,
-      isClosable: false,
-    });
-
-    // フォームの初期化
-    setIsLoading(false);
-    setIsValidate(false);
-    setInputScore(undefined);
-    setInput(initialInput);
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [resStatus]);
 
   const handleRuleSelect = (event: React.ChangeEvent<HTMLSelectElement>) => {
     const value = event.target.value;
@@ -119,7 +82,7 @@ export const ScoreInputField = ({
     });
   };
 
-  const handleClickAddData = () => {
+  const handleClickAddData = async () => {
     setIsLoading(true);
 
     // このような場合は isValidate で弾いてるが、以下で型を正しく推論できるように追加している
@@ -135,7 +98,36 @@ export const ScoreInputField = ({
       rule: input.rule,
       score: input.score * (isScoreMinus ? -1 : 1),
     };
-    postRecord(data, setResStatus);
+    const res = await postRecord(data);
+
+    // データの送信に失敗した場合の処理
+    if (!res || res.status !== 200) {
+      toast({
+        title: "データの送信に失敗しました",
+        status: "error",
+        position: "top",
+        duration: 3000,
+        isClosable: false,
+      });
+
+      setIsLoading(false);
+      return;
+    }
+
+    // データの送信に成功した場合の処理
+    toast({
+      title: "データの送信に成功しました！",
+      status: "success",
+      position: "top",
+      duration: 3000,
+      isClosable: false,
+    });
+
+    // フォームの初期化
+    setIsLoading(false);
+    setIsValidate(false);
+    setInputScore(undefined);
+    setInput(initialInput);
   };
 
   return (

--- a/frontend/components/organisms/ScoreInputField/index.tsx
+++ b/frontend/components/organisms/ScoreInputField/index.tsx
@@ -42,6 +42,7 @@ export const ScoreInputField = ({
   };
   const [input, setInput] = useState<Input>(initialInput);
   const [inputScore, setInputScore] = useState<string | undefined>(undefined);
+  const [isScoreMinus, setIsScoreMinus] = useState<boolean>(false); // スコアがマイナスかどうかの状態
   const [isValidate, setIsValidate] = useState<boolean>(false); // データを送信可能かどうかの状態
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [resStatus, setResStatus] = useState<number>(0);
@@ -132,7 +133,7 @@ export const ScoreInputField = ({
       gameType: 4, // TODO: 後に3麻も増えた場合それに対応する必要がある
       rank: input.rank,
       rule: input.rule,
-      score: input.score,
+      score: input.score * (isScoreMinus ? -1 : 1),
     };
     postRecord(data, setResStatus);
   };
@@ -175,7 +176,12 @@ export const ScoreInputField = ({
             })}
           </HStack>
           <VSpacer size={8} />
-          <ScoreInput value={inputScore} setState={setInputScore} />
+          <ScoreInput
+            isScoreMinus={isScoreMinus}
+            setIsScoreMinus={setIsScoreMinus}
+            value={inputScore}
+            setState={setInputScore}
+          />
           <VSpacer size={8} />
           <TileButton
             type="text"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint --dir api --dir components --dir hooks --dir pages --dir styles --dir stores",
+    "lint": "next lint --dir api --dir components --dir hooks --dir pages --dir stores --dir types --dir utils",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },


### PR DESCRIPTION
## 🔨 変更内容
- マイナススコアがうまく処理できない問題の修正
  - これまでの実装
    - マイナスが押された時に、入力されているスコアに -1 を掛ける
    -> 入力がされていない場合には null のままになり、その後 -1 を掛けるタイミングがないためうまくいっていなかった
  - 修正後
    - データを送信するタイミングで、マイナスが ON になっている場合には -1 を掛けるようにした
-  実装の過程で、連続でデータを送信しようとすると、2回目以降の送信時に、送信成功 or 失敗の描画が走っていなかったため、うまく動くように修正をした

### ⚠注意
- 派生元を https://github.com/ltoppyl/mahjong-score-manage/pull/68 のブランチにしているため、Merge あとに PR を Open にする
- Merge する前に取り込むブランチを変更することを忘れない！！ (to 自分へ)


## 📸 スクリーンショット
![issue-62](https://user-images.githubusercontent.com/68209431/235287213-ccacd60a-c79b-4ddf-986a-b1b3033ca15b.gif)

## 💡 レビューの観点

### PR 作成者のチェック項目

- [ ] セルフレビュー
- [ ] CI/CD がすべて pass している
- [ ] Reviewer の指定

### Reviewer のチェック項目

<!-- PR 作成者が確認してほしいことを追記する-->
<!-- 例) ○○なときxxが△△になる -->

- [ ] コードレビュー

## ✅ 解決するイシュー

- close #62

## 🤝 関連するイシュー

- #62
