### PR TITLE
[BE] 成績を管理する collection を3麻と4麻で分離する

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -49,6 +49,8 @@ def root():
 @app.get("/api/v1/get-records")
 def get_record(userId: str):
     record_list = []
+
+    # TODO: 3麻のデータ取得に対応する際には、gameTypeを引数に追加する
     docs = db.collection("user").document(userId).collection("result").stream()
     for doc in docs:
         record_dic = doc.to_dict()

--- a/backend/main.py
+++ b/backend/main.py
@@ -82,7 +82,7 @@ async def add_record(record: Record):
         doc_ref.set(record_dict)
         doc_id = doc_ref.id
 
-    return "success"
+    return doc_id
 
 
 @app.post("/api/v1/add-user")

--- a/backend/main.py
+++ b/backend/main.py
@@ -65,9 +65,18 @@ async def add_record(record: Record):
     userId = record_dict.pop("userId")
     record_dict["point"] = cal_point(record_dict["score"], record_dict["rank"])
 
-    db.collection("user").document(userId).collection("result").document().set(
-        record_dict
-    )
+    if record_dict["gameType"] == 4:
+        doc_ref = (
+            db.collection("user").document(userId).collection("four-player").document()
+        )
+        doc_ref.set(record_dict)
+        doc_id = doc_ref.id
+    elif record_dict["gameType"] == 3:
+        doc_ref = (
+            db.collection("user").document(userId).collection("three-player").document()
+        )
+        doc_ref.set(record_dict)
+        doc_id = doc_ref.id
 
     return "success"
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from starlette.middleware.cors import CORSMiddleware
 
@@ -64,6 +65,9 @@ async def add_record(record: Record):
     record_dict = record.dict()
     userId = record_dict.pop("userId")
     record_dict["point"] = cal_point(record_dict["score"], record_dict["rank"])
+
+    if record_dict["gameType"] != 4 and record_dict["gameType"] != 3:
+        return JSONResponse(status_code=422, content={"message": "Invalid gameType"})
 
     if record_dict["gameType"] == 4:
         doc_ref = (


### PR DESCRIPTION
## 🔨 変更内容
- 成績を管理する collection を3麻と4麻で分離するようにした
  - 後に、絞り込みなどをする際にこのような仕様のほうが都合が良いと判断したため 

### ⚠注意
#85 のブランチから作成したため #86 が完了した後、base の branch を develop に変更してから Merge する

## 📷 スクリーンショット
![image](https://user-images.githubusercontent.com/68209431/235845456-91e7c188-ea7f-4c9e-a2e3-ea435b3fb118.png)

## 💡 レビューの観点

### PR 作成者のチェック項目
- [x] セルフレビュー
- [x] CI/CD がすべて pass している
- [x] Reviewer の指定

### Reviewer のチェック項目

<!-- PR 作成者が確認してほしいことを追記する-->
<!-- 例) ○○なときxxが△△になる -->

- [ ] コードレビュー

## ✅ 解決するイシュー

- close #76

## 🤝 関連するイシュー

- #76
